### PR TITLE
Display chevron to toggle console

### DIFF
--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -1,4 +1,6 @@
 import { Component, createEffect, createSignal, splitProps, JSX, For, Show } from 'solid-js';
+import { Icon } from '@amoutonbrady/solid-heroicons';
+import { chevronDown, chevronRight } from '@amoutonbrady/solid-heroicons/solid';
 
 export const Preview: Component<Props> = (props) => {
   const [internal, external] = splitProps(props, ['code', 'class']);
@@ -182,9 +184,19 @@ export const Preview: Component<Props> = (props) => {
           <button
             type="button"
             class="text-left font-semibold uppercase text-xs md:text-sm px-2 py-3 focus:outline-none -mb-1 md:-mb-0.5 leading-none md:leading-tight"
+            style={{ position: 'relative' }}
             onClick={() => setShowLogs(!showLogs())}
           >
-            Console ({logs().length})
+            <Icon
+              style={{
+                height: '28px',
+                position: 'absolute',
+                top: '7px',
+                left: '2px',
+              }}
+              path={showLogs() ? chevronDown : chevronRight}
+            />
+            <span class="ml-4">Console ({logs().length})</span>
           </button>
           <button
             type="button"
@@ -196,7 +208,7 @@ export const Preview: Component<Props> = (props) => {
         </div>
 
         <Show when={showLogs()}>
-          <ul class="overflow-auto px-2 divide-y">
+          <ul class="text-xs overflow-auto px-2 divide-y">
             <For each={logs()}>
               {(log) => (
                 <li

--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -183,8 +183,7 @@ export const Preview: Component<Props> = (props) => {
         <div class="flex justify-between items-start w-full">
           <button
             type="button"
-            class="text-left font-semibold uppercase text-xs md:text-sm px-2 py-3 focus:outline-none -mb-1 md:-mb-0.5 leading-none md:leading-tight"
-            style={{ position: 'relative' }}
+            class="relative text-left font-semibold uppercase text-xs md:text-sm px-2 py-3 focus:outline-none -mb-1 md:-mb-0.5 leading-none md:leading-tight"
             onClick={() => setShowLogs(!showLogs())}
           >
             <Icon

--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -188,12 +188,7 @@ export const Preview: Component<Props> = (props) => {
             onClick={() => setShowLogs(!showLogs())}
           >
             <Icon
-              style={{
-                height: '28px',
-                position: 'absolute',
-                top: '7px',
-                left: '2px',
-              }}
+              class="h-[28px] absolute top-[7px] left-[2px]"
               path={showLogs() ? chevronDown : chevronRight}
             />
             <span class="ml-4">Console ({logs().length})</span>


### PR DESCRIPTION
Introduced a chevron on the left of "Console", so it is made clearer for the user that it can be clicked to toggle the console pane.

Also, changed the font-size of the console so that it matches the editor's.

Before:
![image](https://user-images.githubusercontent.com/6893840/117206164-cb557b80-adf2-11eb-8c78-9049266fbd8f.png)

After:
![image](https://user-images.githubusercontent.com/6893840/117206204-dad4c480-adf2-11eb-9e64-69d737e69b9a.png)

